### PR TITLE
Don't ignore errors in copyFile

### DIFF
--- a/build.go
+++ b/build.go
@@ -191,7 +191,7 @@ func copyFile(dst, src string) error {
 		err = os.Chtimes(dst, fi.ModTime(), fi.ModTime())
 	}
 
-	return nil
+	return err
 }
 
 // die prints the message with fmt.Fprintf() to stderr and exits with an error


### PR DESCRIPTION
Hi, this is a drive-by pull request. I just noticed this `return nil` in restic and this seems like the repo where it should be fixed.